### PR TITLE
sk-83: Remove unnecessary relationships from beneficiary details

### DIFF
--- a/web/app/Http/Controllers/Api/BeneficiaryApiController.php
+++ b/web/app/Http/Controllers/Api/BeneficiaryApiController.php
@@ -114,8 +114,6 @@ class BeneficiaryApiController extends Controller
             'generalCarePlan.healthHistory',
             'generalCarePlan.careNeeds',
             'generalCarePlan.careWorkerResponsibility',
-            'portalAccount',
-            'familyMembers',
         ])->findOrFail($id);
 
         // Care worker can only view assigned beneficiaries


### PR DESCRIPTION
- Removed 'portalAccount' and 'familyMembers' from the beneficiary show method.