### PR TITLE
shifts fix: Refactor weekly care plan API methods for improved data h…

### DIFF
--- a/web/app/Http/Controllers/Api/WeeklyCarePlanApiController.php
+++ b/web/app/Http/Controllers/Api/WeeklyCarePlanApiController.php
@@ -170,10 +170,14 @@ class WeeklyCarePlanApiController extends Controller
                     !is_null($request->duration_minutes[$idx]) &&
                     $request->duration_minutes[$idx] > 0
                 ) {
+                    $intervention = \App\Models\Intervention::find($interventionId);
                     WeeklyCarePlanInterventions::create([
                         'weekly_care_plan_id' => $wcp->weekly_care_plan_id,
                         'intervention_id' => $interventionId,
+                        'care_category_id' => $intervention ? $intervention->care_category_id : null,
+                        'intervention_description' => $intervention ? $intervention->intervention_description : null,
                         'duration_minutes' => $request->duration_minutes[$idx],
+                        'implemented' => true,
                     ]);
                 }
             }


### PR DESCRIPTION
…andling

- Changed ordering of weekly care plans to use 'created_at' instead of 'date'
- Added 'beneficiary_id' to the response in the showWeekly method
- Enhanced intervention data mapping in showWeekly method to include care category and description
- Updated store method to save care category and intervention description when creating weekly care plan interventions